### PR TITLE
change deploy workflow to only work on source

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,8 @@ name: JSDoc and Deploy
 
 on:
   pull_request:
+    paths: 
+      - 'source/**'
     branches:
       - main
     types: [closed]

--- a/cypress/integration/sample-test.js
+++ b/cypress/integration/sample-test.js
@@ -1,5 +1,5 @@
 describe('Sample Cypress test', () => {
-    it('finds the content "type"', () => {
+    it('Check for website title"', () => {
       cy.visit('/')
   
       cy.contains('Electric Pomato')


### PR DESCRIPTION
Change the deploy workflow to only run when changes are made to the source directory so we don't have JSDocs going for every change
Can delete the `enhancement/pipeline-new` branch after this merge