### PR TITLE
Limit codacy scan to only our js and scss files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,6 +37,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@main
 
-      - name: Run Codacy Analysis CLI
+      - name: Run Codacy Analysis CLI (JS)
         uses: codacy/codacy-analysis-cli-action@master
-
+        with:
+          - directory: source/js
+      
+      - name: Run Codacy Analysis CLI (SCSS)
+        uses: codacy/codacy-analysis-cli-action@master
+        with:
+          - directory: source/scss


### PR DESCRIPTION
#78 
Changed Codacy to only check files in `source/js` and `source/scss`
I remember the directory parameter was finicky before so I might need multiple tries for this