### PR TITLE
Update end session button behavior

### DIFF
--- a/source/js/components/StatsModal.js
+++ b/source/js/components/StatsModal.js
@@ -45,8 +45,9 @@ class StatsModal extends HTMLElement {
     });
   }
 
-  /*
-   * Opens the stats modal
+  /**
+   * Opens the stats modal, and sets the redirectURL variable if provided
+   * @param {string} redirectURL - URL to redirect to when modal is closed
    */
   open(redirectURL = null) {
     this.wrapper.style.display = 'flex';

--- a/source/js/components/StatsModal.js
+++ b/source/js/components/StatsModal.js
@@ -1,6 +1,7 @@
 /**
  * @file Creates and defines the functionality for the Pomo stats modal.
  * @author Alan Wang
+ * @author Meshach Adoe
  * Date: 05/11/2022
  */
 import zingchart from '../../dependencies/zingchart-es6.min.js';

--- a/source/js/components/StatsModal.js
+++ b/source/js/components/StatsModal.js
@@ -51,6 +51,9 @@ class StatsModal extends HTMLElement {
   open(redirectURL = null) {
     this.wrapper.style.display = 'flex';
     if (redirectURL) {
+      if (redirectURL === './index.html') {
+        this.closeButton.textContent = 'Return to Homepage';
+      }
       this.redirectToOnClose = redirectURL;
     }
     if (backend.get('History') == null) {

--- a/source/js/components/StatsModal.js
+++ b/source/js/components/StatsModal.js
@@ -36,6 +36,7 @@ class StatsModal extends HTMLElement {
     this.wrapper = document.getElementById('stats-wrapper');
     this.closeButton = document.getElementById('stats-close');
     this.lineChartAlt = document.getElementById('line-chart-alt');
+    this.redirectToOnClose = null;
 
     // Set up close button
     this.closeButton.addEventListener('click', () => {
@@ -46,8 +47,11 @@ class StatsModal extends HTMLElement {
   /*
    * Opens the stats modal
    */
-  open() {
+  open(redirectURL = null) {
     this.wrapper.style.display = 'flex';
+    if (redirectURL) {
+      this.redirectToOnClose = redirectURL;
+    }
     if (backend.get('History') == null) {
       this.lineChartAlt.style.display = 'flex';
     } else {
@@ -61,6 +65,9 @@ class StatsModal extends HTMLElement {
    */
   close() {
     this.wrapper.style.display = 'none';
+    if (this.redirectToOnClose) {
+      window.location.href = this.redirectToOnClose;
+    }
   }
 
   /**

--- a/source/js/scripts/app.js
+++ b/source/js/scripts/app.js
@@ -64,21 +64,7 @@ function handleEndOfSession() {
   // Wipe data from previous task list
   backend.removeAll();
 
-  // Pop up prompt
-  const endMessage = {
-    title: 'Congratulations, you have finished this session!',
-    subtitle: 'What would you like to do next?',
-    leftButton: 'Start New Session',
-    rightButton: 'View Logs',
-  };
-
-  PopUp.prompt(endMessage, false).then((result) => {
-    if (result === 'left') {
-      window.location.href = './index.html';
-    } else if (result === 'right') {
-      window.location.href = './done.html';
-    }
-  });
+  document.querySelector('stats-modal').open('./index.html');
 }
 
 /**

--- a/source/js/scripts/app.js
+++ b/source/js/scripts/app.js
@@ -7,13 +7,13 @@
  * @author Teresa Truong
  * @author Annika Hatcher
  * @author Luke Menezes
+ * @author Meshach Adoe
  */
 
 import EditableTaskList from '../components/EditableTaskList.js';
 import ViewOnlyTaskList from '../components/ViewOnlyTaskList.js';
 import TimerUI from '../components/TimerUI.js';
 import BreakPrompt from '../components/BreakPrompt.js';
-import PopUp from '../classes/PopUp.js';
 import TaskList from '../classes/TaskList.js';
 import * as backend from '../backend.js';
 


### PR DESCRIPTION
Closes #70 by adding prop to add a custom redirect URL when the user closes the StatsModal.
Slightly modified expected behavior so that the modal pops up in the end session screen, but navigates to the home page as soon as the modal is closed.