### PR TITLE
Staging workflow fixes

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - '**.js'
     branches-ignore:
-      - 'master'
+      - 'main'
 
 jobs:
   test:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - '**.js'
     branches-ignore:
-      - 'master'
+      - 'main'
 
 jobs:
   lint:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -6,7 +6,6 @@ name: Firebase Preview Deploy and E2E tests
       - 'source/**'
     branches:
       - main
-    types: [opened]
 
 jobs:
   # Build website and deploy to staging area (firebase preview channel)


### PR DESCRIPTION
Closes #109 
Changed staging workflow to run just on pull request, which makes the workflow run on `opened`, `synchronize`, and `reopened` events. This will allow the workflow to run again when someone makes changes to a branch with an open PR (e.g. when they're responding to a review) 
Changed jest and lint workflows to ignore main 