### PR TITLE
Change behavior on resuming session 

### DIFF
--- a/source/__tests__/StartButtons.test.js
+++ b/source/__tests__/StartButtons.test.js
@@ -26,4 +26,27 @@ describe('StartButtons tests', () => {
     // right child button has another child element
     expect(startButtons.lastChild.childElementCount).toBe(1);
   });
+
+  test('Clicking Resume Session when session started', () => {
+    // make a non empty task list and save to local storage
+    const taskList = new TaskList();
+    taskList.createTask('first task', 1);
+    taskList.save();
+ 
+    localStorage.setItem('CurrentPomos', 2); 
+    localStorage.setItem('Started', true);
+
+    // create buttons
+    const startButtons = new StartButtons();
+
+    // Click on resume session anchor
+    startButtons.lastChild.firstChild.click(); 
+
+    // Timer state reset to Pomodoro
+    expect(localStorage.getItem('Timer')).toEqual('true');
+
+    // CurrentPomos reset to 0
+    expect(Number(localStorage.getItem('CurrentPomos'))).toBe(0);
+
+  });
 });

--- a/source/__tests__/StartButtons.test.js
+++ b/source/__tests__/StartButtons.test.js
@@ -33,6 +33,7 @@ describe('StartButtons tests', () => {
     taskList.createTask('first task', 1);
     taskList.save();
  
+    localStorage.setItem('Timer', false);
     localStorage.setItem('CurrentPomos', 2); 
     localStorage.setItem('Started', true);
 

--- a/source/js/backend.js
+++ b/source/js/backend.js
@@ -47,6 +47,7 @@ export function removeAll() {
   localStorage.removeItem('TaskList');
   localStorage.removeItem('Started');
   localStorage.removeItem('TotalPomos');
+  localStorage.removeItem('CurrentPomos');
   localStorage.removeItem('Timer');
   localStorage.removeItem('WorkSessionDuration');
   localStorage.removeItem('ShortBreakDuration');

--- a/source/js/backend.js
+++ b/source/js/backend.js
@@ -36,6 +36,7 @@ export function clearSessionData() {
   localStorage.removeItem('TaskList');
   localStorage.removeItem('Started');
   localStorage.removeItem('TotalPomos');
+  localStorage.removeItem('CurrentPomos');
   localStorage.removeItem('Timer');
 }
 

--- a/source/js/components/StartButtons.js
+++ b/source/js/components/StartButtons.js
@@ -92,6 +92,15 @@ class StartButtons extends HTMLElement {
     a.href = 'app.html';
     a.classList.add('btn', 'btn-secondary', 'btn-lg', 'btn-block');
     a.appendChild(text);
+
+    a.addEventListener('click', () => {
+      // Reset Timer state and current Pomos if session already started
+      if (backend.get('Started') === 'true') {
+        backend.set('Timer', true);
+        backend.set('CurrentPomos', 0);
+      }
+    });
+
     return a;
   }
 }

--- a/source/js/scripts/app.js
+++ b/source/js/scripts/app.js
@@ -277,14 +277,13 @@ function showTimer() {
  */
 function handleOnLoad() {
   // Redirect to index.html if no name is in localStorage.
-  if (!backend.get('Username')) {
+  if (backend.get('Username') == null) {
     window.location.href = 'index.html';
-  } else if (backend.get('Started')) {
-    // On resuming session, reset timer state and current pomos
-    backend.set('Timer', true);
-    backend.set('CurrentPomos', 0);
+  } else if (backend.get('Started') === 'true') {
+    // if started session, go to timer
     showTimer();
   } else {
+    // otherwise, go to task list page
     appContainer.appendChild(new EditableTaskList());
     document.querySelector('.app-title').textContent = `${backend.get('Username')}'s Day`;
     appContainer.querySelectorAll('.start-day-button').forEach((button) => {

--- a/source/js/scripts/app.js
+++ b/source/js/scripts/app.js
@@ -280,7 +280,7 @@ function handleOnLoad() {
   if (!backend.get('Username')) {
     window.location.href = 'index.html';
   } else if (backend.get('Started')) {
-    // On resuming session, reset timer state and current pomos 
+    // On resuming session, reset timer state and current pomos
     backend.set('Timer', true);
     backend.set('CurrentPomos', 0);
     showTimer();

--- a/source/js/scripts/app.js
+++ b/source/js/scripts/app.js
@@ -55,9 +55,9 @@ let votl = null;
  * @return {boolean} true if next break is a long break, false otherwise
  */
 function isLongBreak() {
-  const totalPomos = Number(backend.get('TotalPomos'));
+  const currentPomos = Number(backend.get('CurrentPomos'));
   // If there has been 4 pomos then it is a long break
-  return totalPomos > 0 && totalPomos % 4 === 0;
+  return currentPomos > 0 && currentPomos % 4 === 0;
 }
 
 /**
@@ -233,6 +233,7 @@ function handleClick(timer, taskList) {
           // Increment pomos if we were in a Pomo session
           if (timerState === 'true') {
             backend.set('TotalPomos', Number(backend.get('TotalPomos')) + 1);
+            backend.set('CurrentPomos', Number(backend.get('CurrentPomos')) + 1);
             taskList.addPomo();
           }
 
@@ -261,7 +262,6 @@ function showTimer() {
   votl = new ViewOnlyTaskList();
 
   // Call any helper functions to handle user events.
-  updateAppTitle(false);
   handleClick(timerUI, votl);
   initTimer(timerUI);
 
@@ -280,6 +280,9 @@ function handleOnLoad() {
   if (!backend.get('Username')) {
     window.location.href = 'index.html';
   } else if (backend.get('Started')) {
+    // On resuming session, reset timer state and current pomos 
+    backend.set('Timer', true);
+    backend.set('CurrentPomos', 0);
     showTimer();
   } else {
     appContainer.appendChild(new EditableTaskList());
@@ -289,6 +292,7 @@ function handleOnLoad() {
         backend.set('Started', true);
         backend.set('Timer', true);
         backend.set('TotalPomos', 0);
+        backend.set('CurrentPomos', 0);
         appContainer.lastElementChild.remove();
         showTimer();
       });


### PR DESCRIPTION
Closes #135 
Changed behavior on resuming session to always start at a Pomo session, regardless of what session the user left at 
Added new field `CurrentPomos` to backend to track whether the user is on a short or long break 
`CurrentPomos` will also reset to 0 when the user resumes the session, so the user's progress towards a long break is also reset 
