### PR TITLE
Disable service worker registration in development mode

### DIFF
--- a/source/js/scripts/registerSw.js
+++ b/source/js/scripts/registerSw.js
@@ -1,5 +1,7 @@
-// Service worker
-if ('serviceWorker' in navigator) {
+// Only register the service worker in production to avoid conflicting
+// issues with Parcel's HMR during development.
+// Simply remove the development check if wanting to test service worker updates locally
+if ('serviceWorker' in navigator && process.env.NODE_ENV !== 'development') {
   navigator.serviceWorker.register(new URL('../../serviceWorker.js', import.meta.url), { type: 'module' })
     .then(() => { console.log('Service Worker Register'); });
 }


### PR DESCRIPTION
Just a small issue I found while doing some work over the weekend. When running the app in development mode, any changes made to the app will trigger parcel to update the current build in order see changes instantly take effect. However, our service worker would still be serving up the old file/s cached and thus leading to having to manually refresh the page to see any new changes take effect.

Only register the service worker in production to avoid conflicting issues with Parcel's [HMR] (https://parceljs.org/features/development/) while running app in development mode (locally)