### PR TITLE
Fix issue with service worker failing to install

### DIFF
--- a/source/serviceWorker.js
+++ b/source/serviceWorker.js
@@ -27,16 +27,3 @@ self.addEventListener('fetch', (event) => {
     caches.match(event.request).then((response) => response || fetch(event.request)),
   );
 });
-
-self.addEventListener('notificationclick', (event) => {
-  console.log('On notification click');
-  event.notification.close();
-
-  event.waitUntil(clients.matchAll({
-    type: 'window',
-  }).then((clientList) => {
-    for (let i = 0; i < clientList.length; i += 1) {
-      return clientList[i].focus();
-    }
-  }));
-});

--- a/source/serviceWorker.js
+++ b/source/serviceWorker.js
@@ -2,10 +2,14 @@
 import { manifest, version } from '@parcel/service-worker';
 
 // Cache necessary files when service worker is installed
-self.addEventListener('install', (e) => {
-  self.skipWaiting();
-  e.waitUntil(caches.open(version).then((cache) => cache.addAll(manifest)));
-});
+async function install() {
+  const cache = await caches.open(version);
+  // Filter out any possible duplicate files from manifest
+  const filteredManifest = manifest.filter((item, index) => manifest.indexOf(item) === index);
+  await cache.addAll(filteredManifest);
+}
+
+self.addEventListener('install', (e) => e.waitUntil(install()));
 
 // Clean up old service workers when activated
 async function activate() {
@@ -22,4 +26,17 @@ self.addEventListener('fetch', (event) => {
   event.respondWith(
     caches.match(event.request).then((response) => response || fetch(event.request)),
   );
+});
+
+self.addEventListener('notificationclick', (event) => {
+  console.log('On notification click');
+  event.notification.close();
+
+  event.waitUntil(clients.matchAll({
+    type: 'window',
+  }).then((clientList) => {
+    for (let i = 0; i < clientList.length; i += 1) {
+      return clientList[i].focus();
+    }
+  }));
 });


### PR DESCRIPTION
This should fix our current issues we are experiencing with background notifications and icon theme updates. When adding imports for images, it seemed to have created duplicate file requests in the 'parcel manifest' leading to the service worker failing to install. 

I tested this locally by running build script and then using live server to run the app and notifications appear to be working properly now.