### PR TITLE
Fix task list view on tablet

### DIFF
--- a/source/app.html
+++ b/source/app.html
@@ -135,12 +135,14 @@
     <template id="add-row-template">
         <div class="row g-0">
             <div class="d-none d-lg-block col-lg-1"></div>
-            <div class="col-12 col-sm-7 col-lg-6 d-sm-none">
+            <div class="col-12 col-sm-6 col-lg-6 d-sm-none">
                 <h5 class="fw-bold mb-0">
                     Name:
                 </h5>
             </div>
-            <div class="col-12 col-sm-7 col-lg-6 task-list"><input type="text" value=""></div>
+            <div class="col-12 col-sm-6 col-lg-6 task-list">
+                <input type="text" value="">
+            </div>
             <div class="col-12 col-sm-5 col-lg-3 d-sm-none">
                 <h5 class="fw-bold mb-0">
                     Planned Pomos:


### PR DESCRIPTION
Change tasklist view on tablet so tomatoes line up with title
Before: 
![image](https://user-images.githubusercontent.com/34356748/172266722-a585e234-bccb-439a-b52e-733db426b9a3.png)
After: 
![image](https://user-images.githubusercontent.com/34356748/172266684-5ca78539-dfa0-4e99-a5bc-c440a0a558d4.png)
